### PR TITLE
Make redis_mirror_proxy compatible with `redis-cli`

### DIFF
--- a/server.go
+++ b/server.go
@@ -42,23 +42,31 @@ func redisCommand(conn redcon.Conn, cmd redcon.Command) {
 		case []byte:
 			conn.WriteBulk(v)
 		case []interface{}:
-			conn.WriteArray(len(v))
-			for _, val := range v {
-				switch v := val.(type) {
-				case int64:
-					conn.WriteInt64(v)
-				case string:
-					conn.WriteString(v)
-				case []byte:
-					conn.WriteBulk(v)
-				}
-			}
+			printValue(v, conn)
 		default:
-			log.Println("This is an unknow type!", v, res)
+			log.Printf("This is an unknow type! %T", v)
 		}
 		return
 	case "subscribe", "psubscribe", "publish":
 		conn.WriteError("Unsupported command")
+	}
+}
+
+func printValue(v []interface{}, conn redcon.Conn) {
+	conn.WriteArray(len(v))
+	for _, val := range v {
+		switch v := val.(type) {
+		case int64:
+			conn.WriteInt64(v)
+		case string:
+			conn.WriteString(v)
+		case []byte:
+			conn.WriteBulk(v)
+		case []interface{}:
+			printValue(v, conn)
+		default:
+			log.Printf("This is an unknow type! %T", v)
+		}
 	}
 }
 


### PR DESCRIPTION
Currently, there is an issue when we connect with `redis-cli`. It's because `redis-cli` immediatly executes a `command docs` command when connecting.

`command docs` returns a "complex" answer with nested arrays.

This changes allows to access the proxy using `redis-cli`